### PR TITLE
[bot] Add security workflows & infer codeowners

### DIFF
--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -1,0 +1,17 @@
+name: "Codeowners Validator"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    # Runs at 15:00 UTC every Monday
+    - cron: '0 15 * * 1'
+
+jobs:
+  call-workflow:
+    uses: myhelix/security-workflows/.github/workflows/codeowners-validator.yml@v1.0.0
+    secrets:
+      owners-validator-github-secret: ${{ secrets.OWNERS_VALIDATOR_PUBLIC_GITHUB_SECRET }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,15 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    # Runs at 15:00 UTC every Monday
+    - cron: '0 15 * * 1'
+
+jobs:
+  call-workflow:
+    uses: myhelix/security-workflows/.github/workflows/codeql-analysis-javascript.yml@v1.0.0


### PR DESCRIPTION
This PR was generated by a set of semi-automated scripts. It does the following:

- Add a Code Scanning workflow which runs on every PR and periodically on the primary branch. Code Scanning automatically analyzes code in a GitHub repository to find security vulnerabilities and coding errors. For more information on Code Scanning, see the [GitHub Code Scanning wiki page](https://myhelix.atlassian.net/l/c/0B4pZ2vi).
- Add a Codeowners Validator workflow which runs on every PR and periodically on the primary branch. Codeowners Validator checks that the GitHub CODEOWNERS file is valid.
- Attempt to infer the code owner for this repository based on the information in GitHub. For more information on code owners, see the [Code ownership in GitHub wiki page](https://myhelix.atlassian.net/l/c/MLQRLQqc).

Before merging this PR, please verify that the code owners indicated in the CODEOWNERS file are correct. Please also ensure that the Code Scanning and Codeowners Validators PR status checks both complete without errors.